### PR TITLE
Fix: Sort children pages with Position field

### DIFF
--- a/bl-kernel/pages.class.php
+++ b/bl-kernel/pages.class.php
@@ -657,10 +657,11 @@ class Pages extends dbJSON {
         $list = array();
         foreach ($tmp as $key=>$fields) {
             if (Text::startsWith($key, $parentKey.'/')) {
-                array_push($list, $key);
+                $list[$key]=$fields['position'];
             }
         }
-        return $list;
+        natcasesort($list);
+        return array_keys($list);
     }
 
     public function sortBy()


### PR DESCRIPTION
Children pages are currently not sorted (not in the admin, nor on the public site). This fixes that.